### PR TITLE
feat: add placeholder error handlers to all API calls

### DIFF
--- a/components/AdministratorDashboard.vue
+++ b/components/AdministratorDashboard.vue
@@ -162,16 +162,35 @@ export default defineComponent({
     // Data fetching
 
     function fetchAdminDashboard() {
-      adminApi.getFullWorkitemHistory().then((response) => {
-        workitemsHistory.value = response.data;
-      });
+      adminApi
+        .getFullWorkitemHistory()
+        .then((response) => {
+          workitemsHistory.value = response.data;
+        })
+        .catch(() => {
+          // Error handling is centralized in the Axios interceptor
+          // Handle UI state reset or fallback values here if needed
+        });
 
-      adminApi.getFullErrorsHistory().then((response) => {
-        errorsHistory.value = response.data;
-      });
-      adminApi.getAdminCounts().then((response) => {
-        counts.value = response.data;
-      });
+      adminApi
+        .getFullErrorsHistory()
+        .then((response) => {
+          errorsHistory.value = response.data;
+        })
+        .catch(() => {
+          // Error handling is centralized in the Axios interceptor
+          // Handle UI state reset or fallback values here if needed
+        });
+
+      adminApi
+        .getAdminCounts()
+        .then((response) => {
+          counts.value = response.data;
+        })
+        .catch(() => {
+          // Error handling is centralized in the Axios interceptor
+          // Handle UI state reset or fallback values here if needed
+        });
     }
 
     onMounted(() => {

--- a/components/DashboardAlerts.vue
+++ b/components/DashboardAlerts.vue
@@ -30,9 +30,15 @@ export default defineComponent({
     const dash = ref<DashboardSchema>();
 
     onMounted(() => {
-      dashboardApi.getDashboard().then((response) => {
-        dash.value = response.data;
-      });
+      dashboardApi
+        .getDashboard()
+        .then((response) => {
+          dash.value = response.data;
+        })
+        .catch(() => {
+          // Error handling is centralized in the Axios interceptor
+          // Handle UI state reset or fallback values here if needed
+        });
     });
 
     return {

--- a/components/EMPISearch.vue
+++ b/components/EMPISearch.vue
@@ -103,7 +103,12 @@ export default defineComponent({
             page.value = response.data.page ?? 0;
             total.value = response.data.total ?? 0;
             size.value = response.data.size ?? 0;
-
+          })
+          .catch(() => {
+            // Error handling is centralized in the Axios interceptor
+            // Handle UI state reset or fallback values here if needed
+          })
+          .finally(() => {
             searchInProgress.value = false;
           });
       }

--- a/components/FacilitiesTable.vue
+++ b/components/FacilitiesTable.vue
@@ -114,6 +114,10 @@ export default defineComponent({
         })
         .then((response) => {
           facilities.value = response.data;
+        })
+        .catch(() => {
+          // Error handling is centralized in the Axios interceptor
+          // Handle UI state reset or fallback values here if needed
         });
     }
 

--- a/components/FacilityErrorsHistoryPlot.vue
+++ b/components/FacilityErrorsHistoryPlot.vue
@@ -68,6 +68,10 @@ export default defineComponent({
         })
         .then((response) => {
           facilityErrorsHistory.value = response.data;
+        })
+        .catch(() => {
+          // Error handling is centralized in the Axios interceptor
+          // Handle UI state reset or fallback values here if needed
         });
     }
 

--- a/components/patientrecord/PatientRecordMembershipsMenu.vue
+++ b/components/patientrecord/PatientRecordMembershipsMenu.vue
@@ -61,7 +61,6 @@ export default defineComponent({
   },
   emits: ["refresh"],
   setup(props) {
-    const toast = useToast();
     const { hasPermission } = usePermissions();
     const { ukrdcRecordGroupApi } = useApi();
 
@@ -93,14 +92,9 @@ export default defineComponent({
         .then(() => {
           createPkbMembershipSuccess.value?.show();
         })
-        .catch((error) => {
-          // Notify of task error
-          toast.add({
-            title: "Error creating PKB membership",
-            description: error.response.data.detail,
-            color: "red",
-            timeout: 10,
-          });
+        .catch(() => {
+          // Error handling is centralized in the Axios interceptor
+          // Handle UI state reset or fallback values here if needed
         });
     }
 

--- a/components/plots/stats/BaseMarkdownDescriptionTooltip.vue
+++ b/components/plots/stats/BaseMarkdownDescriptionTooltip.vue
@@ -28,7 +28,7 @@ export default defineComponent({
       if (!props.descriptionMarkdown) {
         return "No description available";
       }
-      return DOMPurify.sanitize(marked.parse(props.descriptionMarkdown));
+      return DOMPurify.sanitize(marked.parse(props.descriptionMarkdown) as string);
     });
 
     return {

--- a/composables/useChannels.ts
+++ b/composables/useChannels.ts
@@ -20,9 +20,14 @@ export default function () {
   function setChannels() {
     // If we don't already have a list of available facilties, fetch one
     if (channels.value.length === 0) {
-      mirthApi.getMirthChannelMap().then((response) => {
-        channels.value = response.data;
-      });
+      mirthApi
+        .getMirthChannelMap()
+        .then((response) => {
+          channels.value = response.data;
+        })
+        .catch(() => {
+          channels.value = [];
+        });
     }
   }
 

--- a/composables/useFacilities.ts
+++ b/composables/useFacilities.ts
@@ -19,9 +19,14 @@ export default function () {
   function setFacilities() {
     // If we don't already have a list of available facilties, fetch one
     if (facilities.value.length === 0) {
-      facilitiesApi.getFacilityList().then((response) => {
-        facilities.value = response.data;
-      });
+      facilitiesApi
+        .getFacilityList()
+        .then((response) => {
+          facilities.value = response.data;
+        })
+        .catch(() => {
+          facilities.value = [];
+        });
     }
   }
 

--- a/composables/useRecordExport.ts
+++ b/composables/useRecordExport.ts
@@ -8,24 +8,42 @@ export default function () {
   const { pollTask } = useTasks();
 
   function exportPV(record: PatientRecordSummarySchema) {
-    return patientRecordsApi.postPatientExportPv({ pid: record.pid }).then((response) => {
-      const task: TrackableTaskSchema = response.data;
-      return pollTask(task, 1);
-    });
+    return patientRecordsApi
+      .postPatientExportPv({ pid: record.pid })
+      .then((response) => {
+        const task: TrackableTaskSchema = response.data;
+        return pollTask(task, 1);
+      })
+      .catch(() => {
+        // Error handling is centralized in the Axios interceptor
+        // Handle UI state reset or fallback values here if needed
+      });
   }
 
   function exportRADAR(record: PatientRecordSummarySchema) {
-    return patientRecordsApi.postPatientExportRadar({ pid: record.pid }).then((response) => {
-      const task: TrackableTaskSchema = response.data;
-      return pollTask(task, 1);
-    });
+    return patientRecordsApi
+      .postPatientExportRadar({ pid: record.pid })
+      .then((response) => {
+        const task: TrackableTaskSchema = response.data;
+        return pollTask(task, 1);
+      })
+      .catch(() => {
+        // Error handling is centralized in the Axios interceptor
+        // Handle UI state reset or fallback values here if needed
+      });
   }
 
   function exportPKB(record: PatientRecordSummarySchema) {
-    return patientRecordsApi.postPatientExportPkb({ pid: record.pid }).then((response) => {
-      const task: TrackableTaskSchema = response.data;
-      return pollTask(task, 1);
-    });
+    return patientRecordsApi
+      .postPatientExportPkb({ pid: record.pid })
+      .then((response) => {
+        const task: TrackableTaskSchema = response.data;
+        return pollTask(task, 1);
+      })
+      .catch(() => {
+        // Error handling is centralized in the Axios interceptor
+        // Handle UI state reset or fallback values here if needed
+      });
   }
 
   return {

--- a/error.vue
+++ b/error.vue
@@ -1,17 +1,14 @@
 <template>
-  <NuxtLayout>
-    <div class="flex h-full flex-col items-center justify-center">
-      <div class="block items-center justify-center sm:flex">
-        <h1 class="sm:mr-8">{{ error.statusCode ?? "Error" }}</h1>
-        <div class="sm:border-l sm:pl-8">
-          <h2 class="whitespace-pre">{{ errorTitle }}</h2>
-          <div v-if="error.message">
-            <p>{{ error.message }}</p>
-          </div>
-        </div>
+  <div class="flex h-screen flex-col items-center justify-center gap-8 divide-x sm:flex-row">
+    <h1>{{ error.statusCode ?? "Error" }}</h1>
+    <div class="pl-8">
+      <h2 class="whitespace-pre">{{ errorTitle }}</h2>
+      <div v-if="error.message">
+        <p>{{ error.message }}</p>
       </div>
+      <UButton to="/" label="Go back" class="mt-2" />
     </div>
-  </NuxtLayout>
+  </div>
 </template>
 
 <script lang="ts">

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -45,7 +45,7 @@
 
       <!-- Main page content -->
       <main class="relative z-0 flex-1 overflow-y-auto focus:outline-none" tabindex="0">
-        <div class="mx-auto max-w-7xl px-4 py-6 sm:px-6 md:px-8">
+        <div class="mx-auto max-w-7xl px-4 pb-24 pt-6 sm:px-6 md:px-8">
           <slot />
         </div>
       </main>

--- a/pages/codes.vue
+++ b/pages/codes.vue
@@ -62,13 +62,10 @@
         </UCard>
       </div>
       <!-- Code details -->
-      <div class="sticky top-4 h-screen grow">
-        <UButton
-          v-show="$route.params.id"
-          class="mb-4 w-full lg:hidden"
-          :to="{ path: `/codes/`, query: $route.query }"
-          label="Back to List"
-        />
+      <div class="sticky top-4 grow">
+        <NuxtLink v-show="$route.params.id" class="w-full lg:hidden" :to="{ path: `/codes/`, query: $route.query }">
+          <UButton class="mb-4 w-full">Back to List</UButton>
+        </NuxtLink>
         <UCard :class="$route.params.id ? 'block' : 'hidden lg:block'" :ui="{ body: { padding: '' } }" class="py-4">
           <NuxtPage />
         </UCard>

--- a/pages/codes.vue
+++ b/pages/codes.vue
@@ -113,24 +113,42 @@ export default defineComponent({
     // Code exporting
 
     function exportCodeList() {
-      codesApi.getCodeListExport().then(({ data }) => {
-        const blob = new Blob([data], { type: "text/plain;charset=utf-8" });
-        saveAs(blob, "code-list.csv");
-      });
+      codesApi
+        .getCodeListExport()
+        .then(({ data }) => {
+          const blob = new Blob([data], { type: "text/plain;charset=utf-8" });
+          saveAs(blob, "code-list.csv");
+        })
+        .catch(() => {
+          // Error handling is centralized in the Axios interceptor
+          // Handle UI state reset or fallback values here if needed
+        });
     }
 
     function exportCodeMaps() {
-      codesApi.getCodeMapsExport().then(({ data }) => {
-        const blob = new Blob([data], { type: "text/plain;charset=utf-8" });
-        saveAs(blob, "code-maps.csv");
-      });
+      codesApi
+        .getCodeMapsExport()
+        .then(({ data }) => {
+          const blob = new Blob([data], { type: "text/plain;charset=utf-8" });
+          saveAs(blob, "code-maps.csv");
+        })
+        .catch(() => {
+          // Error handling is centralized in the Axios interceptor
+          // Handle UI state reset or fallback values here if needed
+        });
     }
 
     function exportCodeExclusions() {
-      codesApi.getCodeExclusionsExport().then(({ data }) => {
-        const blob = new Blob([data], { type: "text/plain;charset=utf-8" });
-        saveAs(blob, "code-exclusions.csv");
-      });
+      codesApi
+        .getCodeExclusionsExport()
+        .then(({ data }) => {
+          const blob = new Blob([data], { type: "text/plain;charset=utf-8" });
+          saveAs(blob, "code-exclusions.csv");
+        })
+        .catch(() => {
+          // Error handling is centralized in the Axios interceptor
+          // Handle UI state reset or fallback values here if needed
+        });
     }
 
     // Data fetching
@@ -149,6 +167,12 @@ export default defineComponent({
           total.value = response.data.total ?? 0;
           page.value = response.data.page ?? 0;
           size.value = response.data.size ?? 0;
+        })
+        .catch(() => {
+          // Error handling is centralized in the Axios interceptor
+          // Handle UI state reset or fallback values here if needed
+        })
+        .finally(() => {
           fetchInProgress.value = false;
         });
     }

--- a/pages/codes/[id].vue
+++ b/pages/codes/[id].vue
@@ -126,6 +126,10 @@ export default defineComponent({
         })
         .then((response) => {
           code.value = response.data;
+        })
+        .catch(() => {
+          // Error handling is centralized in the Axios interceptor
+          // Handle UI state reset or fallback values here if needed
         });
     }
 

--- a/pages/empi/merge.vue
+++ b/pages/empi/merge.vue
@@ -168,6 +168,10 @@ export default defineComponent({
           })
           .then((response) => {
             superseded.value = response.data;
+          })
+          .catch(() => {
+            // Error handling is centralized in the Axios interceptor
+            // Handle UI state reset or fallback values here if needed
           });
       }
       if (supersedingId.value) {
@@ -177,6 +181,10 @@ export default defineComponent({
           })
           .then((response) => {
             superseding.value = response.data;
+          })
+          .catch(() => {
+            // Error handling is centralized in the Axios interceptor
+            // Handle UI state reset or fallback values here if needed
           });
       }
     }
@@ -280,6 +288,10 @@ export default defineComponent({
             if (callbackPath.value) {
               router.push(callbackPath.value);
             }
+          })
+          .catch(() => {
+            // Error handling is centralized in the Axios interceptor
+            // Handle UI state reset or fallback values here if needed
           })
           .finally(() => {
             const el = beginMergeAlert.value as ModalInterface;

--- a/pages/empi/multipleids.vue
+++ b/pages/empi/multipleids.vue
@@ -106,7 +106,12 @@ export default defineComponent({
           total.value = response.data.total ?? 0;
           page.value = response.data.page ?? 0;
           size.value = response.data.size ?? 0;
-
+        })
+        .catch(() => {
+          // Error handling is centralized in the Axios interceptor
+          // Handle UI state reset or fallback values here if needed
+        })
+        .finally(() => {
           fetchInProgress.value = false;
         });
 

--- a/pages/empi/recordworkitems.vue
+++ b/pages/empi/recordworkitems.vue
@@ -84,7 +84,12 @@ export default defineComponent({
           total.value = response.data.total ?? 0;
           page.value = response.data.page ?? 0;
           size.value = response.data.size ?? 0;
-
+        })
+        .catch(() => {
+          // Error handling is centralized in the Axios interceptor
+          // Handle UI state reset or fallback values here if needed
+        })
+        .finally(() => {
           fetchInProgress.value = false;
         });
     }

--- a/pages/facilities/[code].vue
+++ b/pages/facilities/[code].vue
@@ -93,6 +93,10 @@ export default defineComponent({
         })
         .then((response) => {
           facility.value = response.data;
+        })
+        .catch(() => {
+          // Error handling is centralized in the Axios interceptor
+          // Handle UI state reset or fallback values here if needed
         });
       facilitiesApi
         .getFacilityExtracts({
@@ -100,6 +104,10 @@ export default defineComponent({
         })
         .then((response) => {
           extracts.value = response.data;
+        })
+        .catch(() => {
+          // Error handling is centralized in the Axios interceptor
+          // Handle UI state reset or fallback values here if needed
         });
     });
 

--- a/pages/facilities/[code]/errors.vue
+++ b/pages/facilities/[code]/errors.vue
@@ -127,6 +127,10 @@ export default defineComponent({
           errorMessagesPage.value = response.data.page ?? 0;
           errorMessagesSize.value = response.data.size ?? 0;
           errorMessagesTotal.value = response.data.total ?? 0;
+        })
+        .catch(() => {
+          // Error handling is centralized in the Axios interceptor
+          // Handle UI state reset or fallback values here if needed
         });
     }
 

--- a/pages/facilities/[code]/reports/cc001.vue
+++ b/pages/facilities/[code]/reports/cc001.vue
@@ -87,7 +87,12 @@ export default defineComponent({
           total.value = response.data.total ?? 0;
           page.value = response.data.page ?? 0;
           size.value = response.data.size ?? 0;
-
+        })
+        .catch(() => {
+          // Error handling is centralized in the Axios interceptor
+          // Handle UI state reset or fallback values here if needed
+        })
+        .finally(() => {
           fetchInProgress.value = false;
         });
     }

--- a/pages/facilities/[code]/reports/pm001.vue
+++ b/pages/facilities/[code]/reports/pm001.vue
@@ -85,6 +85,13 @@ export default defineComponent({
           size.value = response.data.size ?? 0;
 
           fetchInProgress.value = false;
+        })
+        .catch(() => {
+          // Error handling is centralized in the Axios interceptor
+          // Handle UI state reset or fallback values here if needed
+        })
+        .finally(() => {
+          fetchInProgress.value = false;
         });
     }
 

--- a/pages/facilities/[code]/statistics/demographics.vue
+++ b/pages/facilities/[code]/statistics/demographics.vue
@@ -71,6 +71,10 @@ export default defineComponent({
         })
         .then((response) => {
           facilityStatsDemographics.value = response.data;
+        })
+        .catch(() => {
+          // Error handling is centralized in the Axios interceptor
+          // Handle UI state reset or fallback values here if needed
         });
     });
 

--- a/pages/facilities/[code]/statistics/krt.vue
+++ b/pages/facilities/[code]/statistics/krt.vue
@@ -99,6 +99,10 @@ export default defineComponent({
         })
         .then((response) => {
           facilityStatsDialysis.value = response.data;
+        })
+        .catch(() => {
+          // Error handling is centralized in the Axios interceptor
+          // Handle UI state reset or fallback values here if needed
         });
     });
 

--- a/pages/masterrecords/[id].vue
+++ b/pages/masterrecords/[id].vue
@@ -92,6 +92,10 @@ export default defineComponent({
         })
         .then((response) => {
           record.value = response.data;
+        })
+        .catch(() => {
+          // Error handling is centralized in the Axios interceptor
+          // Handle UI state reset or fallback values here if needed
         });
 
       // Get basic record statistics
@@ -101,6 +105,10 @@ export default defineComponent({
         })
         .then((response) => {
           stats.value = response.data;
+        })
+        .catch(() => {
+          // Error handling is centralized in the Axios interceptor
+          // Handle UI state reset or fallback values here if needed
         });
 
       // Generate issues warning message

--- a/pages/masterrecords/[id]/index.vue
+++ b/pages/masterrecords/[id]/index.vue
@@ -157,6 +157,10 @@ export default defineComponent({
         })
         .then((response) => {
           patientRecords.value = response.data;
+        })
+        .catch(() => {
+          // Error handling is centralized in the Axios interceptor
+          // Handle UI state reset or fallback values here if needed
         });
 
       masterRecordsApi
@@ -165,6 +169,10 @@ export default defineComponent({
         })
         .then((response) => {
           relatedRecords.value = response.data;
+        })
+        .catch(() => {
+          // Error handling is centralized in the Axios interceptor
+          // Handle UI state reset or fallback values here if needed
         });
 
       masterRecordsApi
@@ -174,6 +182,10 @@ export default defineComponent({
         .then((response) => {
           latestMessage.value = response.data;
           latestMessageIsLoading.value = false;
+        })
+        .catch(() => {
+          // Error handling is centralized in the Axios interceptor
+          // Handle UI state reset or fallback values here if needed
         });
     }
 

--- a/pages/masterrecords/[id]/issues.vue
+++ b/pages/masterrecords/[id]/issues.vue
@@ -154,6 +154,10 @@ export default defineComponent({
           .then((response) => {
             workItems.value = response.data;
           })
+          .catch(() => {
+            // Error handling is centralized in the Axios interceptor
+            // Handle UI state reset or fallback values here if needed
+          })
           .finally(() => {
             workItemsFetchInProgress.value = false;
           });
@@ -174,6 +178,10 @@ export default defineComponent({
           relatedErrorsPage.value = response.data.page ?? 0;
           relatedErrorsSize.value = response.data.size ?? 0;
           relatedErrorsTotal.value = response.data.total ?? 0;
+        })
+        .catch(() => {
+          // Error handling is centralized in the Axios interceptor
+          // Handle UI state reset or fallback values here if needed
         });
     }
 
@@ -204,6 +212,10 @@ export default defineComponent({
               });
             }
             ukrdcIdGroup.value = multipleIdsGroup;
+          })
+          .catch(() => {
+            // Error handling is centralized in the Axios interceptor
+            // Handle UI state reset or fallback values here if needed
           });
       }
     }

--- a/pages/masterrecords/[id]/linkrecords.vue
+++ b/pages/masterrecords/[id]/linkrecords.vue
@@ -51,6 +51,10 @@ export default defineComponent({
         })
         .then((response) => {
           linkRecords.value = response.data;
+        })
+        .catch(() => {
+          // Error handling is centralized in the Axios interceptor
+          // Handle UI state reset or fallback values here if needed
         });
     });
 

--- a/pages/masterrecords/[id]/messages.vue
+++ b/pages/masterrecords/[id]/messages.vue
@@ -97,6 +97,10 @@ export default defineComponent({
           total.value = response.data.total ?? 0;
           page.value = response.data.page ?? 0;
           size.value = response.data.size ?? 0;
+        })
+        .catch(() => {
+          // Error handling is centralized in the Axios interceptor
+          // Handle UI state reset or fallback values here if needed
         });
     }
 

--- a/pages/messages/[id].vue
+++ b/pages/messages/[id].vue
@@ -55,6 +55,10 @@ export default defineComponent({
         })
         .then((response) => {
           message.value = response.data;
+        })
+        .catch(() => {
+          // Error handling is centralized in the Axios interceptor
+          // Handle UI state reset or fallback values here if needed
         });
     });
 

--- a/pages/messages/[id]/index.vue
+++ b/pages/messages/[id]/index.vue
@@ -169,6 +169,10 @@ export default defineComponent({
           })
           .then((response) => {
             patientRecords.value = response.data;
+          })
+          .catch(() => {
+            // Error handling is centralized in the Axios interceptor
+            // Handle UI state reset or fallback values here if needed
           });
       }
       if (hasPermission("ukrdc:workitems:read")) {
@@ -178,6 +182,10 @@ export default defineComponent({
           })
           .then((response) => {
             workItems.value = response.data;
+          })
+          .catch(() => {
+            // Error handling is centralized in the Axios interceptor
+            // Handle UI state reset or fallback values here if needed
           });
       }
 
@@ -205,6 +213,10 @@ export default defineComponent({
         .then((response) => {
           const blob = new Blob([response.data.content ? response.data.content : ""]);
           saveAs(blob, props.message.filename ?? `${props.message.facility}-{message.id}.txt`);
+        })
+        .catch(() => {
+          // Error handling is centralized in the Axios interceptor
+          // Handle UI state reset or fallback values here if needed
         });
     }
 

--- a/pages/messages/index.vue
+++ b/pages/messages/index.vue
@@ -170,6 +170,10 @@ export default defineComponent({
           page.value = response.data.page ?? 0;
           size.value = response.data.size ?? 0;
         })
+        .catch(() => {
+          // Error handling is centralized in the Axios interceptor
+          // Handle UI state reset or fallback values here if needed
+        })
         .finally(() => {
           fetchInProgress.value = false;
         });

--- a/pages/mirth/index.vue
+++ b/pages/mirth/index.vue
@@ -60,9 +60,15 @@ export default defineComponent({
 
     // Data fetching
     onMounted(() => {
-      mirthApi.getMirthGroups().then((response) => {
-        mirthGroups.value = response.data;
-      });
+      mirthApi
+        .getMirthGroups()
+        .then((response) => {
+          mirthGroups.value = response.data;
+        })
+        .catch(() => {
+          // Error handling is centralized in the Axios interceptor
+          // Handle UI state reset or fallback values here if needed
+        });
     });
 
     return {

--- a/pages/mirth/messages/[channel]/[id].vue
+++ b/pages/mirth/messages/[channel]/[id].vue
@@ -44,6 +44,10 @@ export default defineComponent({
         })
         .then((response) => {
           message.value = response.data;
+        })
+        .catch(() => {
+          // Error handling is centralized in the Axios interceptor
+          // Handle UI state reset or fallback values here if needed
         });
     });
 

--- a/pages/patientrecords/[pid].vue
+++ b/pages/patientrecords/[pid].vue
@@ -65,6 +65,10 @@ export default defineComponent({
         })
         .then((response) => {
           record.value = response.data;
+        })
+        .catch(() => {
+          // Error handling is centralized in the Axios interceptor
+          // Handle UI state reset or fallback values here if needed
         });
     }
 

--- a/pages/patientrecords/[pid]/audit.vue
+++ b/pages/patientrecords/[pid]/audit.vue
@@ -131,6 +131,10 @@ export default defineComponent({
           page.value = response.data.page ?? 0;
           size.value = response.data.size ?? 0;
         })
+        .catch(() => {
+          // Error handling is centralized in the Axios interceptor
+          // Handle UI state reset or fallback values here if needed
+        })
         .finally(() => {
           auditFetchInProgress.value = false;
         });

--- a/pages/patientrecords/[pid]/index.vue
+++ b/pages/patientrecords/[pid]/index.vue
@@ -163,6 +163,10 @@ export default defineComponent({
         })
         .then((response) => {
           related.value = response.data;
+        })
+        .catch(() => {
+          // Error handling is centralized in the Axios interceptor
+          // Handle UI state reset or fallback values here if needed
         });
 
       // Get latest message data
@@ -173,6 +177,10 @@ export default defineComponent({
         .then((response) => {
           latestMessage.value = response.data;
           latestMessageIsLoading.value = false;
+        })
+        .catch(() => {
+          // Error handling is centralized in the Axios interceptor
+          // Handle UI state reset or fallback values here if needed
         });
     }
 

--- a/pages/patientrecords/[pid]/medical/diagnoses.vue
+++ b/pages/patientrecords/[pid]/medical/diagnoses.vue
@@ -95,6 +95,10 @@ export default defineComponent({
         })
         .then((response) => {
           diagnoses.value = response.data;
+        })
+        .catch(() => {
+          // Error handling is centralized in the Axios interceptor
+          // Handle UI state reset or fallback values here if needed
         });
 
       patientRecordsApi
@@ -103,6 +107,10 @@ export default defineComponent({
         })
         .then((response) => {
           renalDiagnoses.value = response.data;
+        })
+        .catch(() => {
+          // Error handling is centralized in the Axios interceptor
+          // Handle UI state reset or fallback values here if needed
         });
 
       patientRecordsApi
@@ -111,6 +119,10 @@ export default defineComponent({
         })
         .then((response) => {
           causesOfDeath.value = response.data;
+        })
+        .catch(() => {
+          // Error handling is centralized in the Axios interceptor
+          // Handle UI state reset or fallback values here if needed
         });
     });
 

--- a/pages/patientrecords/[pid]/medical/dialysis.vue
+++ b/pages/patientrecords/[pid]/medical/dialysis.vue
@@ -93,6 +93,10 @@ export default defineComponent({
           page.value = response.data.page ?? 0;
           size.value = response.data.size ?? 0;
         })
+        .catch(() => {
+          // Error handling is centralized in the Axios interceptor
+          // Handle UI state reset or fallback values here if needed
+        })
         .finally(() => {
           loading.value = false;
         });

--- a/pages/patientrecords/[pid]/medical/documents/[docid].vue
+++ b/pages/patientrecords/[pid]/medical/documents/[docid].vue
@@ -122,6 +122,10 @@ export default defineComponent({
         })
         .then((response) => {
           patientDocument.value = response.data;
+        })
+        .catch(() => {
+          // Error handling is centralized in the Axios interceptor
+          // Handle UI state reset or fallback values here if needed
         });
     });
 
@@ -143,6 +147,10 @@ export default defineComponent({
         .then((response) => {
           const blob = new Blob([response.data]);
           saveAs(blob, patientDocument.value?.filename ?? `${patientDocument.value?.documentname}.txt`);
+        })
+        .catch(() => {
+          // Error handling is centralized in the Axios interceptor
+          // Handle UI state reset or fallback values here if needed
         });
     }
 

--- a/pages/patientrecords/[pid]/medical/documents/index.vue
+++ b/pages/patientrecords/[pid]/medical/documents/index.vue
@@ -68,6 +68,10 @@ export default defineComponent({
           total.value = response.data.total ?? 0;
           page.value = response.data.page ?? 0;
           size.value = response.data.size ?? 0;
+        })
+        .catch(() => {
+          // Error handling is centralized in the Axios interceptor
+          // Handle UI state reset or fallback values here if needed
         });
     }
 

--- a/pages/patientrecords/[pid]/medical/laborders.vue
+++ b/pages/patientrecords/[pid]/medical/laborders.vue
@@ -69,6 +69,10 @@ export default defineComponent({
           page.value = response.data.page ?? 0;
           size.value = response.data.size ?? 0;
         })
+        .catch(() => {
+          // Error handling is centralized in the Axios interceptor
+          // Handle UI state reset or fallback values here if needed
+        })
         .finally(() => {
           loading.value = false;
         });

--- a/pages/patientrecords/[pid]/medical/medications.vue
+++ b/pages/patientrecords/[pid]/medical/medications.vue
@@ -58,6 +58,10 @@ export default defineComponent({
         })
         .then((response) => {
           medications.value = response.data;
+        })
+        .catch(() => {
+          // Error handling is centralized in the Axios interceptor
+          // Handle UI state reset or fallback values here if needed
         });
     });
 

--- a/pages/patientrecords/[pid]/medical/observations.vue
+++ b/pages/patientrecords/[pid]/medical/observations.vue
@@ -91,6 +91,10 @@ export default defineComponent({
           page.value = response.data.page ?? 0;
           size.value = response.data.size ?? 0;
         })
+        .catch(() => {
+          // Error handling is centralized in the Axios interceptor
+          // Handle UI state reset or fallback values here if needed
+        })
         .finally(() => {
           loading.value = false;
         });
@@ -103,6 +107,10 @@ export default defineComponent({
           })
           .then((response) => {
             availableCodes.value = response.data;
+          })
+          .catch(() => {
+            // Error handling is centralized in the Axios interceptor
+            // Handle UI state reset or fallback values here if needed
           });
       }
     }

--- a/pages/patientrecords/[pid]/medical/results.vue
+++ b/pages/patientrecords/[pid]/medical/results.vue
@@ -159,6 +159,10 @@ export default defineComponent({
           page.value = response.data.page ?? 0;
           size.value = response.data.size ?? 0;
         })
+        .catch(() => {
+          // Error handling is centralized in the Axios interceptor
+          // Handle UI state reset or fallback values here if needed
+        })
         .finally(() => {
           loading.value = false;
         });
@@ -171,6 +175,10 @@ export default defineComponent({
           })
           .then((response) => {
             availableServices.value = response.data;
+          })
+          .catch(() => {
+            // Error handling is centralized in the Axios interceptor
+            // Handle UI state reset or fallback values here if needed
           });
       }
     }
@@ -186,6 +194,10 @@ export default defineComponent({
           })
           .then((response) => {
             selectedOrder.value = response.data;
+          })
+          .catch(() => {
+            // Error handling is centralized in the Axios interceptor
+            // Handle UI state reset or fallback values here if needed
           });
       }
     }
@@ -222,6 +234,10 @@ export default defineComponent({
             fetchResults();
             itemToDelete.value = null;
             deleteResultAlert.value?.hide();
+          })
+          .catch(() => {
+            // Error handling is centralized in the Axios interceptor
+            // Handle UI state reset or fallback values here if needed
           });
       }
     }
@@ -242,6 +258,10 @@ export default defineComponent({
             fetchResults();
             fetchLabOrder();
             deleteOrderAlert.value?.hide();
+          })
+          .catch(() => {
+            // Error handling is centralized in the Axios interceptor
+            // Handle UI state reset or fallback values here if needed
           });
       }
     }

--- a/pages/patientrecords/[pid]/medical/surveys/[surveyid].vue
+++ b/pages/patientrecords/[pid]/medical/surveys/[surveyid].vue
@@ -110,6 +110,10 @@ export default defineComponent({
 
           // Assign data
           survey.value = thisSurvey;
+        })
+        .catch(() => {
+          // Error handling is centralized in the Axios interceptor
+          // Handle UI state reset or fallback values here if needed
         });
     });
 

--- a/pages/patientrecords/[pid]/medical/surveys/index.vue
+++ b/pages/patientrecords/[pid]/medical/surveys/index.vue
@@ -64,6 +64,10 @@ export default defineComponent({
         })
         .then((response) => {
           surveys.value = response.data;
+        })
+        .catch(() => {
+          // Error handling is centralized in the Axios interceptor
+          // Handle UI state reset or fallback values here if needed
         });
     });
 

--- a/pages/patientrecords/[pid]/medical/treatments.vue
+++ b/pages/patientrecords/[pid]/medical/treatments.vue
@@ -109,6 +109,10 @@ export default defineComponent({
         .then((response) => {
           treatments.value = response.data;
         })
+        .catch(() => {
+          // Error handling is centralized in the Axios interceptor
+          // Handle UI state reset or fallback values here if needed
+        })
         .finally(() => {
           loading.value = false;
         });

--- a/pages/patientrecords/[pid]/messages.vue
+++ b/pages/patientrecords/[pid]/messages.vue
@@ -87,6 +87,10 @@ export default defineComponent({
           total.value = response.data.total ?? 0;
           page.value = response.data.page ?? 0;
           size.value = response.data.size ?? 0;
+        })
+        .catch(() => {
+          // Error handling is centralized in the Axios interceptor
+          // Handle UI state reset or fallback values here if needed
         });
     }
 

--- a/pages/patientrecords/[pid]/update/demographics.vue
+++ b/pages/patientrecords/[pid]/update/demographics.vue
@@ -258,6 +258,10 @@ export default defineComponent({
         })
         .then((response) => {
           related.value = response.data;
+        })
+        .catch(() => {
+          // Error handling is centralized in the Axios interceptor
+          // Handle UI state reset or fallback values here if needed
         });
     }
 

--- a/pages/patientrecords/index.vue
+++ b/pages/patientrecords/index.vue
@@ -147,7 +147,12 @@ export default defineComponent({
             page.value = response.data.page ?? 0;
             total.value = response.data.total ?? 0;
             size.value = response.data.size ?? 0;
-
+          })
+          .catch(() => {
+            // Error handling is centralized in the Axios interceptor
+            // Handle UI state reset or fallback values here if needed
+          })
+          .finally(() => {
             searchInProgress.value = false;
           });
       }

--- a/pages/system.vue
+++ b/pages/system.vue
@@ -91,9 +91,15 @@ export default defineComponent({
     // Data fetching
 
     onMounted(() => {
-      systemInfoApi.getSystemInfo().then((response) => {
-        serverInfo.value = response.data;
-      });
+      systemInfoApi
+        .getSystemInfo()
+        .then((response) => {
+          serverInfo.value = response.data;
+        })
+        .catch(() => {
+          // Error handling is centralized in the Axios interceptor
+          // Handle UI state reset or fallback values here if needed
+        });
     });
 
     // Config reports

--- a/pages/tasks.vue
+++ b/pages/tasks.vue
@@ -59,17 +59,18 @@ export default defineComponent({
     const tasks = ref([] as TrackableTaskSchema[]);
 
     // Data fetching
-
-    async function getTasks() {
-      const tasksPage = await fetchTasksList(page.value ?? 1, size.value);
-      tasks.value = tasksPage.items;
-      total.value = tasksPage.total ?? 0;
-      page.value = tasksPage.page ?? 0;
-      size.value = tasksPage.size ?? 0;
-    }
-
-    onMounted(async () => {
-      await getTasks();
+    onMounted(() => {
+      fetchTasksList(page.value ?? 1, size.value)
+        .then((response) => {
+          tasks.value = response.items;
+          total.value = response.total ?? 0;
+          page.value = response.page ?? 0;
+          size.value = response.size ?? 0;
+        })
+        .catch(() => {
+          // Error handling is centralized in the Axios interceptor
+          // Handle UI state reset or fallback values here if needed
+        });
     });
 
     const columns = [

--- a/pages/workitems/[id].vue
+++ b/pages/workitems/[id].vue
@@ -343,6 +343,10 @@ export default defineComponent({
           messagesPage.value = response.data.page ?? 0;
           messagesSize.value = response.data.size ?? 0;
           messagesTotal.value = response.data.total ?? 0;
+        })
+        .catch(() => {
+          // Error handling is centralized in the Axios interceptor
+          // Handle UI state reset or fallback values here if needed
         });
     }
 
@@ -354,6 +358,10 @@ export default defineComponent({
         .then((response) => {
           record.value = response.data;
           isWIP.value = response.data.status === 2;
+        })
+        .catch(() => {
+          // Error handling is centralized in the Axios interceptor
+          // Handle UI state reset or fallback values here if needed
         });
 
       workItemsApi
@@ -362,6 +370,10 @@ export default defineComponent({
         })
         .then((response) => {
           workItemCollection.value = response.data;
+        })
+        .catch(() => {
+          // Error handling is centralized in the Axios interceptor
+          // Handle UI state reset or fallback values here if needed
         });
 
       updateRelatedMessages();

--- a/pages/workitems/index.vue
+++ b/pages/workitems/index.vue
@@ -138,6 +138,10 @@ export default defineComponent({
           total.value = response.data.total ?? 0;
           size.value = response.data.size ?? 0;
         })
+        .catch(() => {
+          // Error handling is centralized in the Axios interceptor
+          // Handle UI state reset or fallback values here if needed
+        })
         .finally(() => {
           fetchInProgress.value = false;
         });


### PR DESCRIPTION
Adds explicit error handlers to all API calls. This ensures that errors don't get double-reported to Sentry as unhandled. In most cases, we want to let the Axios interceptor show the user that an error occurred (using a toast), then leave the page rendered but with no data.

The Axios interceptor handles reporting to Sentry, so in most cases no further action is required.