### PR TITLE
fix: fix facility searching by description/name

### DIFF
--- a/components/FacilitiesTable.vue
+++ b/components/FacilitiesTable.vue
@@ -96,7 +96,7 @@ export default defineComponent({
           // Filter by search term
           .filter(
             (option) =>
-              option.id.toLowerCase().includes(searchboxString.value.toLowerCase()) ??
+              option.id.toLowerCase().includes(searchboxString.value.toLowerCase()) ||
               option.description?.toLowerCase().includes(searchboxString.value.toLowerCase()),
           )
           // Filter by additional filters, such as PkbOut


### PR DESCRIPTION
Fixes an issue where the wrong operator was used to enable searching facilities by either code or name/description