### PR TITLE
feat: 2-character minimum length on search terms

### DIFF
--- a/composables/query/useRecordSearch.ts
+++ b/composables/query/useRecordSearch.ts
@@ -37,7 +37,7 @@ export default function () {
   function searchSubmit(): void {
     // Populates the 'search' URL query array from the search text box string.
     // e.g. 'john & 1970-03-01' becomes ['john', '1949-03-01']
-    if (searchboxString.value) {
+    if (searchboxString.value && searchboxString.value.length > 1) {
       const sections: string[] = searchboxString.value.split("&");
       searchTermArray.value = sections.map(function (s: string) {
         return s.trim();


### PR DESCRIPTION
Adds a 2 character minimum length on search terms before performing the search. Used to prevent filling the audit logs with erroneous searches.

Closes https://renalregistry.atlassian.net/jira/software/c/projects/UI/issues/UI-161