### PR TITLE
feat: switch to a modal for stats info

### DIFF
--- a/components/base/BaseInfoModal.vue
+++ b/components/base/BaseInfoModal.vue
@@ -1,0 +1,33 @@
+<template>
+  <div>
+    <UTooltip :text="tooltip">
+      <UIcon
+        name="i-heroicons-information-circle"
+        class="h-5 w-5 cursor-pointer text-gray-500 hover:text-gray-800"
+        @click="isOpen = true"
+      />
+    </UTooltip>
+
+    <UModal v-model="isOpen">
+      <slot />
+    </UModal>
+  </div>
+</template>
+
+<script lang="ts">
+export default defineComponent({
+  props: {
+    tooltip: {
+      type: String,
+      required: false,
+      default: "Click to show info",
+    },
+  },
+
+  setup() {
+    const isOpen = ref(false);
+
+    return { isOpen };
+  },
+});
+</script>

--- a/components/plots/stats/BaseMarkdownDescriptionTooltip.vue
+++ b/components/plots/stats/BaseMarkdownDescriptionTooltip.vue
@@ -1,19 +1,19 @@
 <!-- eslint-disable vue/no-v-html -->
 <template>
-  <BaseInfoTooltip>
-    <div class="max-h-96 max-w-2xl [&>ul]:list-inside [&>ul]:list-disc" v-html="sanitisedDescriptionHTML"></div>
-  </BaseInfoTooltip>
+  <BaseInfoModal>
+    <div class="space-y-4 p-4 [&>ul]:list-inside [&>ul]:list-disc" v-html="sanitisedDescriptionHTML"></div>
+  </BaseInfoModal>
 </template>
 
 <script lang="ts">
 import DOMPurify from "dompurify";
 import { marked } from "marked";
 
-import BaseInfoTooltip from "~/components/base/BaseInfoTooltip.vue";
+import BaseInfoModal from "~/components/base/BaseInfoModal.vue";
 
 export default defineComponent({
   components: {
-    BaseInfoTooltip,
+    BaseInfoModal,
   },
   props: {
     descriptionMarkdown: {


### PR DESCRIPTION
Replaces the old tooltip-based UI for showing stats calculation information to a full scrollable modal. Allows for far more information to be included in a more readable layout. Also improves element spacing within the information.