### PR TITLE
fix: replace url in history on overview redirect

### DIFF
--- a/pages/facilities/[code]/index.vue
+++ b/pages/facilities/[code]/index.vue
@@ -2,7 +2,7 @@
 export default defineComponent({
   setup() {
     const route = useRoute();
-    navigateTo(`/facilities/${route.params.code}/overview`);
+    navigateTo(`/facilities/${route.params.code}/overview`, { replace: true });
   },
 });
 </script>

--- a/pages/masterrecords/[id]/index.vue
+++ b/pages/masterrecords/[id]/index.vue
@@ -2,7 +2,7 @@
 export default defineComponent({
   setup() {
     const route = useRoute();
-    navigateTo(`/masterrecords/${route.params.id}/overview`);
+    navigateTo(`/masterrecords/${route.params.id}/overview`, { replace: true });
   },
 });
 </script>

--- a/pages/patientrecords/[pid]/index.vue
+++ b/pages/patientrecords/[pid]/index.vue
@@ -2,7 +2,7 @@
 export default defineComponent({
   setup() {
     const route = useRoute();
-    navigateTo(`/patientrecords/${route.params.pid}/overview`);
+    navigateTo(`/patientrecords/${route.params.pid}/overview`, { replace: true });
   },
 });
 </script>


### PR DESCRIPTION
Properly sets the `replace` argument on navigateTo calls. 

Previously, these calls used to send the over to another page by default caused the back button to break since both the old and new URLs were kept in the browser history. Replacing, rather than appending, the new URL allows the back functionality in browsers to function properly again.