### PR TITLE
revert: remove the options to creating memberships and syncing data for MRC

### DIFF
--- a/components/patientrecord/PatientRecordMembershipsMenu.vue
+++ b/components/patientrecord/PatientRecordMembershipsMenu.vue
@@ -156,13 +156,13 @@ export default defineComponent({
           },
           disabled: !props.showCreatePkbMembership,
         },
-        {
-          label: "Create MRC Membership",
-          click: () => {
-            showCreateMrcMembershipConfirm();
-          },
-          disabled: !props.showCreateMrcMembership,
-        },
+        // {
+        //   label: "Create MRC Membership",
+        //   click: () => {
+        //     showCreateMrcMembershipConfirm();
+        //   },
+        //   disabled: !props.showCreateMrcMembership,
+        // },
       ],
     ];
 

--- a/components/patientrecord/PatientRecordMembershipsMenu.vue
+++ b/components/patientrecord/PatientRecordMembershipsMenu.vue
@@ -115,9 +115,9 @@ export default defineComponent({
       createPkbMembershipConfirm.value?.show();
     }
 
-    function showCreateMrcMembershipConfirm() {
-      createMrcMembershipConfirm.value?.show();
-    }
+    // function showCreateMrcMembershipConfirm() {
+    //   createMrcMembershipConfirm.value?.show();
+    // }
 
     function createPkbMembership() {
       ukrdcRecordGroupApi

--- a/components/patientrecord/PatientRecordSyncAllMenuMRC.vue
+++ b/components/patientrecord/PatientRecordSyncAllMenuMRC.vue
@@ -26,7 +26,7 @@
       <p class="mt-3 font-mono">exportAllToMRC.fail {{ failedPIDs }}</p>
     </BaseModalSuccess>
 
-    <UTooltip
+    <!-- <UTooltip
       :text="!hasMrcMembership ? 'Patient does not have a MRC membership record' : undefined"
       :prevent="hasMrcMembership"
     >
@@ -37,7 +37,7 @@
         :disabled="!hasMrcMembership || syncInProgress"
         @click="exportAllToMRC"
       />
-    </UTooltip>
+    </UTooltip> -->
   </div>
 </template>
 


### PR DESCRIPTION
just commenting out the code for the MRC buttons, but everything is still there in case we decide to add it back later. Any issues with that approach beyond the obvious which is it's not a very good way to handle it?